### PR TITLE
ci: auto-deploy to GitHub Pages on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# Let in-flight deploys finish but only keep the latest queued one.
+concurrency:
+  group: gh-pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile
+
+      # Builds with homepage=/blutils-ui/ (from package.json); CI=true treats
+      # lint warnings as errors, matching local `yarn build`.
+      - run: yarn build
+
+      - name: Publish to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build


### PR DESCRIPTION
The site is currently published manually with `yarn deploy`, so merges to `main` don't reach the live page. This adds a GitHub Actions workflow that builds and publishes `./build` to the `gh-pages` branch (the existing Pages source) on every push to `main`, with a manual `workflow_dispatch` trigger as well.

- Uses the production homepage (`/blutils-ui/`) baked into the build.
- `CI=true` keeps the build warning-free, matching local `yarn build`.
- Publishing via `peaceiris/actions-gh-pages` with the built-in `GITHUB_TOKEN` (no extra secrets).

After this merges, future merges to `main` deploy automatically — no more manual `yarn deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)